### PR TITLE
Fix width issue of products suggestions in autocomplete

### DIFF
--- a/src/view/frontend/web/css/style.less
+++ b/src/view/frontend/web/css/style.less
@@ -24,7 +24,7 @@
 
         li.qs-option-product .qs-option-info-container {
             float: left;
-            max-width: calc(100% - 70px);
+            max-width: ~"calc(100% - 70px)";
         }
     }
 
@@ -102,12 +102,12 @@
         &:hover {
             &:before {
                 opacity: 1;
-                bottom: calc(100% + 24px);
+                bottom: ~"calc(100% + 24px)";
             }
 
             &:after {
                 opacity: 1;
-                bottom: calc(100% + 10px);
+                bottom: ~"calc(100% + 10px)";
             }
         }
     }


### PR DESCRIPTION
The wrong notation was used. This caused that the wrong value was set for max-width

This fixes issue https://github.com/EmicoEcommerce/Magento2Tweakwise/issues/32