### PR TITLE
Load product collection before getting size of the product collection

### DIFF
--- a/src/Model/Catalog/Product/AbstractCollection.php
+++ b/src/Model/Catalog/Product/AbstractCollection.php
@@ -110,4 +110,13 @@ abstract class AbstractCollection extends ProductCollection
 
         return $this;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSize()
+    {
+        $this->load();
+        return parent::getSize();
+    }
 }


### PR DESCRIPTION
By loading the product collection the query is updated with filters based on the response of the call that is made to the Tweakwise Navigator API. This needs to be done because otherwise all the products are counted and this results in selecting the wrong template for the search results.

This will fix issue https://github.com/EmicoEcommerce/Magento2Tweakwise/issues/34