### PR TITLE
Bugfix aroundGetItemLimit wrong parameter count

### DIFF
--- a/src/Block/Catalog/Product/ProductList/Upsell/Plugin.php
+++ b/src/Block/Catalog/Product/ProductList/Upsell/Plugin.php
@@ -48,16 +48,16 @@ class Plugin extends AbstractRecommendationPlugin
      * @param Closure $proceed
      * @return int
      */
-    public function aroundGetItemLimit(Upsell $subject, Closure $proceed)
+    public function aroundGetItemLimit(Upsell $subject, Closure $proceed, $type = '')
     {
         if (!$this->config->isRecommendationsEnabled(Config::RECOMMENDATION_TYPE_UPSELL)) {
-            return $proceed();
+            return $proceed($type);
         }
 
         try {
             return $this->getCollection()->count();
         } catch (ApiException $e) {
-            return $proceed();
+            return $proceed($type);
         }
     }
 }


### PR DESCRIPTION
Solves issue with Array conversion error on https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml#L160

Steps:
https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml#L82

https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Catalog/Block/Product/ProductList/Upsell.php#L227

Because type = upsell is not returned it will return this line
https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Catalog/Block/Product/ProductList/Upsell.php#L230

