### PR TITLE
Fix undefined e element when submitting an empty search text

### DIFF
--- a/src/view/frontend/web/js/quick-search.js
+++ b/src/view/frontend/web/js/quick-search.js
@@ -34,12 +34,16 @@ define([
         },
 
         _onSubmit: function (e) {
-            var url = this.getSelectedProductUrl();
-            if (!url) {
-                return this._superApply(e);
+            var value = this.element.val().trim(),
+                url = this.getSelectedProductUrl();
+
+            if (!value) {
+                e.preventDefault();
             }
 
-            window.location.href = url;
+            if (url !== null) {
+                window.location.href = url;
+            }
         },
 
         _onPropertyChange: function () {


### PR DESCRIPTION
When a user wants to do a search and fills in an empty string (space) and then hits enter on the keyboard (especially on mobile devices with gboard this is an issue) a js error is thrown. This happens because this.superApply(e) is not passing the e correctly to the parent function. Instead of that a much simpler solution is implemented.

**Steps to reproduce**
1. Go to any webshop with the latest tweakwise extension installed
2. Go to the search bar in the homepage
3. Press space on your keybpard and submit an empty string by pressing the "Enter" button on your keaboard
4. An error is thrown in the console that "element e is undefined"