### PR TITLE
Prevent decode to URI param a string with a "+" character

### DIFF
--- a/src/view/frontend/web/js/navigation-form.js
+++ b/src/view/frontend/web/js/navigation-form.js
@@ -56,7 +56,7 @@ define(['jquery', 'jquery/ui'], function($) {
         _getQParam: function() {
             let matches = window.location.search.match(/(\?|&)q\=([^&]*)/);
             if (matches && matches[2]) {
-                let trimmedMatch = matches[2].replace("+"," "),
+                let trimmedMatch = matches[2].replace(/\+/g, ' '),
                     searchVal    = jQuery('#search').val();
 
                 if (searchVal === trimmedMatch) {

--- a/src/view/frontend/web/js/navigation-form.js
+++ b/src/view/frontend/web/js/navigation-form.js
@@ -56,6 +56,13 @@ define(['jquery', 'jquery/ui'], function($) {
         _getQParam: function() {
             let matches = window.location.search.match(/(\?|&)q\=([^&]*)/);
             if (matches && matches[2]) {
+                let trimmedMatch = matches[2].replace("+"," "),
+                    searchVal    = jQuery('#search').val();
+
+                if (searchVal === trimmedMatch) {
+                    return decodeURIComponent(trimmedMatch);
+                }
+
                 return decodeURIComponent(matches[2]);
             }
 


### PR DESCRIPTION
During searching in tweakwise a string with 2 words (for example Big Ball) tweakwise will generate a URL in magento "..catalogsearch/result/?q=Big+Ball'.
Later on on result page if someone tries to apply a new filter, the function _getQParam is reading the URL to check if there is anything after q.
Therefore the variable matches[2] will include a string like "Big+Ball" because is fetched from the URL. When later on, the same function will try to decode this string will generate an incorrect URL with searching the "Big+Ball" instead of "Big Ball". New Url would be '../?q=Big%2BBall'.

In this commit a change is being done in the function _getQParam. This change will first check if string that the user is actually searching for something that contains a "+" or not (always possible someone wants to search for 'Big+Ball').
If the case is that the user is just searching for 'Big Ball' then this string needs to be decoded to a param, generating a correct url.