### PR TITLE
Fix for when TW returns attributes

### DIFF
--- a/src/Model/Client.php
+++ b/src/Model/Client.php
@@ -123,6 +123,8 @@ class Client
         return $this->responseFactory->create($request, $result);
     }
 
+    
+
     /**
      * @param SimpleXMLElement $element
      * @return array
@@ -139,21 +141,32 @@ class Client
             if ($index === '@attributes') {
                 continue;
             }
-            if ($node instanceof SimpleXMLElement) {
-                $value = $this->xmlToArray($node);
-            } elseif (is_array($node)) {
-                $value = [];
-                foreach ($node as $element) {
-                    $value[] = $this->xmlToArray($element);
-                }
-            } else {
-                $value = (string) $node;
-            }
 
-            $result[$index] = $value;
+            $result[$index] = $this->xmlToArrayValue($node);
         }
 
         return $result;
+    }
+
+    /**
+     * @param mixed $value
+     * @return array|string
+     */
+    protected function xmlToArrayValue($value)
+    {
+        if ($value instanceof SimpleXMLElement) {
+            return $this->xmlToArray($value);
+        }
+
+        if (is_array($value)) {
+            $values = [];
+            foreach ($value as $element) {
+                $values[] = $this->xmlToArrayValue($element);
+            }
+            return $values;
+        }
+
+        return (string) $value;
     }
 
     /**


### PR DESCRIPTION
When TW returns attribute values this then the `xmlToArray` method will not always be an array of `SimpleXMLElement` but it will be an array of strings. Thus trying to pass a string into the type hinted `$element` argument.