### PR TITLE
Fix exception in Model\Catalog\Layer\Filter::getOptionLabelValueMap

### DIFF
--- a/src/Model/Catalog/Layer/Filter.php
+++ b/src/Model/Catalog/Layer/Filter.php
@@ -344,7 +344,7 @@ class Filter extends AbstractFilter implements FilterInterface
             $map = [];
             /** @var Option $option */
             foreach ($this->getAttributeModel()->getOptions() as $option) {
-                $map[$option->getLabel()] = $option->getValue();
+                $map[(string)$option->getLabel()] = $option->getValue();
             }
 
             $this->optionLabelValueMap = $map;


### PR DESCRIPTION
```
private function getOptionLabelValueMap()
{
    if (!$this->hasAttributeModel()) {
        return [];
    }

    if ($this->optionLabelValueMap === null) {
        $map = [];
        /** @var Option $option */
        foreach ($this->getAttributeModel()->getOptions() as $option) {
            $map[$option->getLabel()] = $option->getValue();
        }

        $this->optionLabelValueMap = $map;
    }
    return $this->optionLabelValueMap;
}
```

`$option->getLabel()` isn't always a string. When using a product attribute of type Boolean it is an object `Magento\Framework\Phrase` and in that case the code returns an exception:

```
Exception #0 (Exception): Warning: Illegal offset type in /.../vendor/emico/tweakwise/src/Model/Catalog/Layer/Filter.php on line 347
```

I wouldn't use labels for keys, but if you really need it make sure it's a string.