### PR TITLE
Sorttype checks invalid index in response array

### DIFF
--- a/src/Model/Client/Type/SortFieldType.php
+++ b/src/Model/Client/Type/SortFieldType.php
@@ -41,7 +41,7 @@ class SortFieldType extends Type
      */
     public function getIsSelected()
     {
-        return $this->getBoolValue('isdirectsearch');
+        return $this->getBoolValue('isselected');
     }
 
     /**


### PR DESCRIPTION
Sorttype checks invalid index in response array to get selected sort item

See response

Emico\Tweakwise\Model\Client\Type\SortFieldType::__set_state(array(
   'data' => 
  array (
    'title' => 'Populair',
    'displaytitle' => 'Populair',
    'order' => 'ASC',
    'isselected' => 'true',
    'url' => '?tn_cid=100022&tn_sort=Populair',
  ),
))