### PR TITLE
Incorrect URL for category filter fixes

### DIFF
--- a/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
@@ -507,18 +507,26 @@ class PathSlugStrategy implements
 
         $category = $this->strategyHelper->getCategoryFromItem($item);
         $categoryUrlPath = \parse_url($category->getUrl(), PHP_URL_PATH);
+
         /*
         Make sure we dont have any double slashes, add the current filter path to the category url to maintain
         the currently selected filters.
         */
         $filterSlugPath = $this->buildFilterSlugPath($this->getActiveFilters());
-        return $this->magentoUrl->getDirectUrl(
+
+        $url = $this->magentoUrl->getDirectUrl(
             sprintf(
                 '%s/%s',
                 trim($categoryUrlPath, '/'),
                 ltrim($filterSlugPath, '/')
             )
         );
+
+        /*
+         We explode the url by using a backslash as separator and then filter the values
+         by an array_unique. In the end we implode again using a backslash to build the correct URL.
+         */
+        return implode('/', array_unique(explode('/', $url)));
     }
 
     /**

--- a/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/PathSlugStrategy.php
@@ -523,8 +523,9 @@ class PathSlugStrategy implements
         );
 
         /*
-         We explode the url by using a backslash as separator and then filter the values
-         by an array_unique. In the end we implode again using a backslash to build the correct URL.
+         We explode the url so that we can capture its parts and find the double values in order to remove them.
+         This is needed because the categoryUrlPath contains the store code in some cases and the directUrl as well.
+         These two are the only unique parts in this situation and so need to be removed.
          */
         return implode('/', array_unique(explode('/', $url)));
     }

--- a/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
@@ -175,12 +175,17 @@ class QueryParameterStrategy implements UrlInterface, FilterApplierInterface, Ca
         if (!$this->getSearch($request)) {
             $categoryUrl = $category->getUrl();
             $categoryUrlPath = \parse_url($categoryUrl, PHP_URL_PATH);
-            return $this->url->getDirectUrl(
+
+            $url = $this->url->getDirectUrl(
                 trim($categoryUrlPath, '/'),
                 [
                     '_query' => $this->getAttributeFilters($request)
                 ]
             );
+
+            $url = str_replace($this->url->getBaseUrl(), '', $url);
+
+            return $url;
         }
 
         $urlKey = $item->getFilter()->getUrlKey();

--- a/Model/Catalog/Layer/Url/StrategyHelper.php
+++ b/Model/Catalog/Layer/Url/StrategyHelper.php
@@ -11,6 +11,7 @@ use Emico\TweakwiseExport\Model\Helper as ExportHelper;
 use Magento\Catalog\Api\CategoryRepositoryInterface;
 use Magento\Catalog\Api\Data\CategoryInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\StoreManagerInterface;
 
 class StrategyHelper
 {
@@ -25,16 +26,24 @@ class StrategyHelper
     private $categoryRepository;
 
     /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
      * StrategyHelper constructor.
      * @param ExportHelper $exportHelper
      * @param CategoryRepositoryInterface $categoryRepository
+     * @param StoreManagerInterface $storeManager
      */
     public function __construct(
         ExportHelper $exportHelper,
-        CategoryRepositoryInterface $categoryRepository
+        CategoryRepositoryInterface $categoryRepository,
+        StoreManagerInterface $storeManager
     ) {
         $this->exportHelper = $exportHelper;
         $this->categoryRepository = $categoryRepository;
+        $this->storeManager = $storeManager;
     }
 
     /**
@@ -47,6 +56,12 @@ class StrategyHelper
         $tweakwiseCategoryId = $item->getAttribute()->getAttributeId();
         $categoryId = $this->exportHelper->getStoreId($tweakwiseCategoryId);
 
-        return $this->categoryRepository->get($categoryId);
+        try {
+            $storeId = $this->storeManager->getStore()->getId();
+        } catch (NoSuchEntityException $exception) {
+            $storeId = null;
+        }
+
+        return $this->categoryRepository->get($categoryId, $storeId);
     }
 }


### PR DESCRIPTION
- Add storeId if available in `StrategyHelper::getCategoryFromItem`. If no store is found, use `null`;
- Remove double store code from url in `PathSlugStrategy::getCategoryFilterSelectUrl`
- Remove double store code from url in `QueryParameterStrategy::getCategoryFilterSelectUrl`

Fixes #149 