### PR TITLE
Add 'Use default value' checkbox to category attributes

### DIFF
--- a/Model/Category/DataProvider/Plugin.php
+++ b/Model/Category/DataProvider/Plugin.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Emico\Tweakwise\Model\Category\DataProvider;
+
+use Magento\Catalog\Model\Category\DataProvider as CategoryDataProvider;
+use Magento\Eav\Model\Config;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\AuthorizationInterface;
+use Magento\Framework\Exception\LocalizedException;
+
+class Plugin
+{
+    /**
+     * @var Config
+     */
+    protected $eavConfig;
+
+    /**
+     * @var AuthorizationInterface
+     */
+    private $auth;
+
+    /**
+     * DataProvider constructor.
+     *
+     * @param Config                      $eavConfig
+     * @param AuthorizationInterface|null $auth
+     */
+    public function __construct(
+        Config $eavConfig,
+        ?AuthorizationInterface $auth = null
+    ) {
+        $this->eavConfig = $eavConfig;
+        $this->auth      = $auth ?? ObjectManager::getInstance()->get(AuthorizationInterface::class);
+    }
+
+    /**
+     * @param CategoryDataProvider $subject
+     * @param array                $meta
+     *
+     * @return array
+     *
+     * @throws LocalizedException
+     */
+    public function afterPrepareMeta(CategoryDataProvider $subject, $meta)
+    {
+        $meta = array_replace_recursive(
+            $meta,
+            $this->prepareFieldsMeta(
+                $this->getFieldsMap(),
+                $subject->getAttributesMeta($this->eavConfig->getEntityType('catalog_category'))
+            )
+        );
+
+        return $meta;
+    }
+
+    /**
+     * @param array $fieldsMap
+     * @param array $fieldsMeta
+     *
+     * @return array
+     */
+    private function prepareFieldsMeta($fieldsMap, $fieldsMeta)
+    {
+        $canEditDesign = $this->auth->isAllowed('Magento_Catalog::edit_category_design');
+
+        $result = [];
+        foreach ($fieldsMap as $fieldSet => $fields) {
+            foreach ($fields as $field) {
+                if (isset($fieldsMeta[$field])) {
+                    $config = $fieldsMeta[$field];
+                    if (($fieldSet === 'design' || $fieldSet === 'schedule_design_update') && !$canEditDesign) {
+                        $config['required']        = 1;
+                        $config['disabled']        = 1;
+                        $config['serviceDisabled'] = true;
+                    }
+
+                    $result[$fieldSet]['children'][$field]['arguments']['data']['config'] = $config;
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getFieldsMap()
+    {
+        return [
+            'tweakwise' => [
+                'tweakwise_featured_template',
+                'tweakwise_crosssell_template',
+                'tweakwise_crosssell_group_code',
+                'tweakwise_upsell_template',
+                'tweakwise_upsell_group_code',
+            ],
+        ];
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -66,6 +66,10 @@
     <type name="Magento\Framework\View\Page\Config">
         <plugin name="emico-tweakwise" type="Emico\Tweakwise\Model\Seo\Robots\Plugin" />
     </type>
+    <!-- Add meta of custom fields to data provider -->
+    <type name="Magento\Catalog\Model\Category\DataProvider">
+        <plugin name="emico-tweakwise" type="Emico\Tweakwise\Model\Category\DataProvider\Plugin" />
+    </type>
 
     <!-- If you need other layouts or possible even layer objects register them here -->
     <type name="Emico\Tweakwise\Controller\Ajax\Navigation">


### PR DESCRIPTION
The custom category attributes from tweakwise lack the checkbox "Use Default Value" when on a store view scope. Sadly Magento uses a hard coded list for this, see \Magento\Catalog\Model\Category\DataProvider::getFieldsMap. With this plugin we can add the Tweakwise attributes to the list and make the "Use Default Value" checkbox visible on store view scope.