### PR TITLE
fix(sorting-plp): Remove parent selector

### DIFF
--- a/view/frontend/web/js/toolbar.js
+++ b/view/frontend/web/js/toolbar.js
@@ -25,10 +25,10 @@ define([
             var hasForm = $(this.options.filterFormSelector).length > 0;
             this.options.ajaxFilters = this.options.ajaxFilters && hasForm;
 
-            this._bind(element.find(options.modeControl), options.mode, options.modeDefault);
-            this._bind(element.find(options.directionControl), options.direction, options.directionDefault);
-            this._bind(element.find(options.orderControl), options.order, options.orderDefault);
-            this._bind(element.find(options.limitControl), options.limit, options.limitDefault);
+            this._bind($(options.modeControl), options.mode, options.modeDefault);
+            this._bind($(options.directionControl), options.direction, options.directionDefault);
+            this._bind($(options.orderControl), options.order, options.orderDefault);
+            this._bind($(options.limitControl), options.limit, options.limitDefault);
             if (options.ajaxFilters) {
                 $(element).on('click', options.pagerItemSelector, this.handlePagerClick.bind(this));
             }


### PR DESCRIPTION
We ran into an issue with the sorting on the plp. 

The sorting JS code uses a parent selector to find the elements. But when the parent selector is not used in the template or if multiple elements with the parent-selctor classnames are existing, the code will only use the last parent element to search for the sorting elements.

Removed the parent selector. Magento default uses [role=""] selectors to search for the elements. This works.