### PR TITLE
Bugfix: it's not possible to remove the last filter because the code …

### DIFF
--- a/view/frontend/web/js/navigation-form.js
+++ b/view/frontend/web/js/navigation-form.js
@@ -329,6 +329,8 @@ define([
             var filterUrl = this._getFilterParameters();
             if (filterUrl) {
                 window.location = '?' + filterUrl;
+            } else {
+                window.location = window.location.href.replace(window.location.search, '');
             }
         }
         // ------- End of handling for form filters


### PR DESCRIPTION
Bugfix: it's not possible to remove the last filter because the code will never enter the if statement if filterUrl is null.
When you have multiple filters selected you can remove filters until you reach the last one, then the checkbox gets unselected but the page will not refresh.