### PR TITLE
Add missing magento/framework dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "ext-simplexml": "*",
         "ext-libxml": "*",
         "emico/tweakwise-export": ">=4.0",
-        "guzzlehttp/guzzle": ">=6.0"
+        "guzzlehttp/guzzle": ">=6.0",
+        "magento/framework": "*"
     },
     "require-dev": {
         "malukenho/docheader": "~0.1",


### PR DESCRIPTION
This fixes the following error when running `composer install`:

    PHP Fatal error:  Uncaught Error: Class 'Magento\Framework\Component\ComponentRegistrar' not found in /path/to/EmicoEcommerce/Magento2Tweakwise/vendor/emico/tweakwise-export/registration.php:11
    Stack trace:
    #0 /path/to/EmicoEcommerce/Magento2Tweakwise/vendor/composer/autoload_real.php(71): require()
    #1 /path/to/EmicoEcommerce/Magento2Tweakwise/vendor/composer/autoload_real.php(61): composerRequire58da530b8c249485889ac3c8a0a1c1bd('6b295ea0b2080c1...', '/path/to...')
    #2 /path/to/EmicoEcommerce/Magento2Tweakwise/vendor/autoload.php(7): ComposerAutoloaderInit58da530b8c249485889ac3c8a0a1c1bd::getLoader()
    #3 /path/to/EmicoEcommerce/Magento2Tweakwise/vendor/phpro/grumphp/bin/grumphp(13): require_once('/path/to...')
    #4 /path/to/EmicoEcommerce/Magento2Tweakwise/vendor/phpro/grumphp/bin/grumphp(51): {closure}()
    #5 {main}
        thrown in /path/to/EmicoEcommerce/Magento2Tweakwise/vendor/emico/tweakwise-export/registration.php on line 11

This error occurs because the `registration.php` file is part of the Composer autoload configuration, and this references classes from the `magento/framework` package.