### PR TITLE
Update GrumPHP configuration

### DIFF
--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,4 +1,4 @@
-parameters:
+grumphp:
     tasks:
         composer_script:
             script: docheader


### PR DESCRIPTION
This fixes the following error when running `composer install`:

    PHP Fatal error:  Uncaught GrumPHP\Exception\DeprecatedException: Direct configuration of parameter tasks is not allowed anymore.
    Please rename the `parameters` section in your grumphp.yaml file to `grumphp`.
    More info: https://github.com/phpro/grumphp/releases/tag/v0.19.0

     in /path/to/EmicoEcommerce/Magento2Tweakwise/vendor/phpro/grumphp/src/Exception/DeprecatedException.php:11
    Stack trace:
    #0 /path/to/EmicoEcommerce/Magento2Tweakwise/vendor/phpro/grumphp/src/Configuration/GrumPHPExtension.php(40): GrumPHP\Exception\DeprecatedException::directParameterConfiguration('tasks')
    #1 /path/to/EmicoEcommerce/Magento2Tweakwise/vendor/phpro/grumphp/src/Configuration/GrumPHPExtension.php(17): GrumPHP\Configuration\GrumPHPExtension->loadInternal(Array, Object(Symfony\Component\DependencyInjection\Compiler\MergeExtensionConfigurationContainerBuilder))
    #2 /path/to/EmicoEcommerce/Magento2Tweakwise/vendor/symfony/dependency-injection/Compiler/MergeExtensionConfigurationPass.php(76): GrumPH in /path/to/EmicoEcommerce/Magento2Tweakwise/vendor/phpro/grumphp/src/Exception/DeprecatedException.php on line 11