### PR TITLE
Avoid API Exceptions for empty product template ids

### DIFF
--- a/Block/Catalog/Product/ProductList/Related/Plugin.php
+++ b/Block/Catalog/Product/ProductList/Related/Plugin.php
@@ -34,6 +34,9 @@ class Plugin extends AbstractRecommendationPlugin
         if (!$this->config->isRecommendationsEnabled(Config::RECOMMENDATION_TYPE_CROSSSELL)) {
             return $proceed();
         }
+        if (!$this->templateFinder->forProduct($subject->getProduct(), $this->getType())) {
+            return $proceed();
+        }
 
         try {
             return $this->getCollection();

--- a/Block/Catalog/Product/ProductList/Upsell/Plugin.php
+++ b/Block/Catalog/Product/ProductList/Upsell/Plugin.php
@@ -35,6 +35,9 @@ class Plugin extends AbstractRecommendationPlugin
         if (!$this->config->isRecommendationsEnabled(Config::RECOMMENDATION_TYPE_UPSELL)) {
             return $proceed();
         }
+        if (!$this->templateFinder->forProduct($subject->getProduct(), $this->getType())) {
+            return $proceed();
+        }
 
         try {
             return $this->getCollection();


### PR DESCRIPTION
When retrieving the the related/upsell relations of a product for which the corresponding crosssell/upsell template id is empty, an `\Emico\Tweakwise\Exception\ApiException` is triggered with the following message:

    Featured products without template ID was requested.

This exception is caught later on and is written as an error to the `system.log`.

However, imho this scenario is not an actual error.

Also, this might give rise to lots of error messages, which pollutes the `system.log` (and services that process errors from these logs like Sentry and Elasticsearch).

This PR fixes these issues by adding an extra check to the Related and Upsell plugins before trying to perform a request to Tweakwise.