### PR TITLE
ADD: Counter to swatch checkbox

### DIFF
--- a/Block/LayeredNavigation/RenderLayered/SwatchRenderer.php
+++ b/Block/LayeredNavigation/RenderLayered/SwatchRenderer.php
@@ -174,4 +174,20 @@ class SwatchRenderer extends RenderLayered
     {
         return $this->filter->getItemByOptionId($id);
     }
+
+    /**
+     * @return SettingsType
+     */
+    protected function getFacetSettings()
+    {
+        return $this->filter->getFacet()->getFacetSettings();
+    }
+
+    /**
+     * @return bool
+     */
+    public function shouldDisplayProductCountOnLayer()
+    {
+        return $this->getFacetSettings()->getIsNumberOfResultVisible();
+    }
 }

--- a/view/frontend/templates/product/layered/swatch.phtml
+++ b/view/frontend/templates/product/layered/swatch.phtml
@@ -79,6 +79,18 @@
                             ><?= /* @escapeNotVerified */ $swatchData['swatches'][$option]['value'] ?></div>
                             <?php    break;
                     } ?>
+                    <?php if ($block->shouldDisplayProductCountOnLayer()): ?>
+                        <span class="count">
+                            <?=htmlentities($item->getCount())?>
+                            <span class="filter-count-label">
+                                <?php if ($item->getCount() == 1):?>
+                                    <?=__('item')?>
+                                <?php else:?>
+                                    <?=__('items')?>
+                                <?php endif;?>
+                            </span>
+                        </span>
+                    <?php endif; ?>
                 <?php } ?>
                 </label>
             </a>

--- a/view/frontend/web/css/style.less
+++ b/view/frontend/web/css/style.less
@@ -132,6 +132,16 @@
     }
 
     .swatch-attribute-options {
+        > label {
+            display: flex;
+            gap: 1ch;
+
+            .swatch-option {
+                height: 24px;
+                width: 24px;
+            }
+        }
+        
         input[type='checkbox']:checked {
             + label .swatch-option {
                 outline: 2px solid #ee0000;


### PR DESCRIPTION
I happened to notice there's a product-count missing for swatches in the filter.