### PR TITLE
Disable Reflected XSS on de slider confguration

### DIFF
--- a/view/frontend/templates/product/layered/slider.phtml
+++ b/view/frontend/templates/product/layered/slider.phtml
@@ -31,7 +31,7 @@ $disabledSliderUrlInputValue = sprintf('%s-%s', $minValue, $maxValue);
             <span class="postfix"><?= $itemPostfix ?></span>
         </span>
     </div>
-    <div class="slider" data-mage-init='<?=$block->getJsSliderConfig()?>'></div>
+    <div class="slider" data-mage-init="<?=$block->escapeHtmlAttr($block->getJsSliderConfig())?>"></div>
     <div class="labels">
         <span class="current-min-value">
             <span class="prefix"><?= $itemPrefix ?></span>


### PR DESCRIPTION
The Slider configuration contains the current url, which could be escaped adding a single quote `'`.

This way it was possible to add reflected XSS in the URL
For obvious reasons I will not add the URL's used here.