### PR TITLE
Fix ajax url

### DIFF
--- a/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
@@ -128,10 +128,15 @@ class QueryParameterStrategy implements UrlInterface, FilterApplierInterface, Ca
         if ($originalUrl = $request->getQuery('__tw_original_url')) {
             $urlArray = explode('/', $originalUrl);
             foreach ($urlArray as $url) {
-                $originalUrl .= '/' . filter_var($url, FILTER_SANITIZE_ENCODED);
+                $newOriginalUrl .= '/' . filter_var($url, FILTER_SANITIZE_ENCODED);
             }
 
-            return $this->url->getDirectUrl($originalUrl, $params);
+            //check if string should start with an / to prevent double slashes later
+            if (strpos(mb_substr($originalUrl, 0, 1), '/', ) === false) {
+                $newOriginalUrl = mb_substr($newOriginalUrl, 1);
+            }
+
+            return $this->url->getDirectUrl($newOriginalUrl, $params);
         }
         return $this->url->getUrl('*/*/*', $params);
     }

--- a/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
@@ -127,6 +127,7 @@ class QueryParameterStrategy implements UrlInterface, FilterApplierInterface, Ca
 
         if ($originalUrl = $request->getQuery('__tw_original_url')) {
             $urlArray = explode('/', $originalUrl);
+            $newOriginalUrl = '';
             foreach ($urlArray as $url) {
                 $newOriginalUrl .= '/' . filter_var($url, FILTER_SANITIZE_ENCODED);
             }


### PR DESCRIPTION
Fixes ajax url in url bar.

When ajax filtering is enabled, selecting a filter returns the wrong url

http://magento.test/women/tops-women/tanks-women.html/women/tops-women/tanks-women.html?new%5b0%5d=Yes

instead of

http://magento.test/women/tops-women/tanks-women.html?new%5B0%5D=Yes
