### PR TITLE
Fix ajax caching personal merchandising

### DIFF
--- a/Model/NavigationConfig.php
+++ b/Model/NavigationConfig.php
@@ -121,8 +121,9 @@ class NavigationConfig implements ArgumentInterface, FilterFormInputProviderInte
             if ($pmCookieName) {
                 $navigationFormConfig['tweakwisePMPageReload'] = [
                     'cookieName' => $pmCookieName,
-                    'reloadList' => !$this->request->isAjax()
+                    'reloadList' => !$this->request->isAjax(),
                 ];
+                $navigationFormConfig['tweakwiseNavigationForm']['ajaxCache'] = false;
             }
         }
         return $this->jsonSerializer->serialize($navigationFormConfig);

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -142,6 +142,7 @@
                 <item name="object_id" xsi:type="string">__tw_object_id</item>
                 <item name="original_url" xsi:type="string">__tw_original_url</item>
                 <item name="ajax_type" xsi:type="string">__tw_ajax_type</item>
+                <item name="ajax_cache" xsi:type="string">_</item>
             </argument>
         </arguments>
     </type>

--- a/view/frontend/web/js/navigation-form.js
+++ b/view/frontend/web/js/navigation-form.js
@@ -25,6 +25,7 @@ define([
             noteMessageSelector: '.message.note',
             noticeMessageSelector: '.message.notice',
             isLoading: false,
+            ajaxCache: true,
         },
 
         currentXhr: null,
@@ -187,7 +188,7 @@ define([
             this.currentXhr = $.ajax({
                 url: this.options.ajaxEndpoint,
                 data: this._getFilterParameters(),
-                cache: true,
+                cache: this.options.ajaxCache,
                 success: function (response) {
                     this._updateBlocks(response.html);
                     this._updateState(response);


### PR DESCRIPTION
This fixes Ajax caching when personal merchandising is on.

The Ajax requests should not be cached because the order of products changes on the page.

How to reproduce the bug

- Configure personal merchandising.
- Op an catalog page with personal merchandising
- Change the order of products on the catalog page, for example by visiting an product (depends on the configured personal merchandising)
- Visit the same catalog page again (don't use the browser back button)

Expected result
- The order of products has changed.

Actual result
- No ajax request is executed and the cached browser request result is shown. So the order of products has not changed.