### PR TITLE
Don't reload first page for personal merchandising

### DIFF
--- a/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
+++ b/Model/Catalog/Layer/Url/Strategy/QueryParameterStrategy.php
@@ -366,8 +366,7 @@ class QueryParameterStrategy implements UrlInterface, FilterApplierInterface, Ca
             $navigationRequest->setLimit($limit);
         }
 
-        // Add this only for ajax requests
-        if ($this->tweakwiseConfig->isPersonalMerchandisingActive() && $request->isAjax()) {
+        if ($this->tweakwiseConfig->isPersonalMerchandisingActive()) {
             $profileKey = $this->cookieManager->getCookie(
                 $this->tweakwiseConfig->getPersonalMerchandisingCookieName(),
                 null

--- a/Model/NavigationConfig.php
+++ b/Model/NavigationConfig.php
@@ -119,9 +119,13 @@ class NavigationConfig implements ArgumentInterface, FilterFormInputProviderInte
         if ($this->config->isPersonalMerchandisingActive()) {
             $pmCookieName = $this->config->getPersonalMerchandisingCookieName();
             if ($pmCookieName) {
+                $module = $this->request->getModuleName();
+                $controller = $this->request->getControllerName();
+                $result = (!($this->request->getModuleName() == 'tweakwise' && $this->request->getControllerName() == 'ajax'));
                 $navigationFormConfig['tweakwisePMPageReload'] = [
                     'cookieName' => $pmCookieName,
-                    'reloadList' => !$this->request->isAjax(),
+                    //'reloadList' => false,
+                    'reloadList' => (!($this->request->getModuleName() == 'tweakwise' && $this->request->getControllerName() == 'ajax')),
                 ];
                 $navigationFormConfig['tweakwiseNavigationForm']['ajaxCache'] = false;
             }

--- a/Model/NavigationConfig.php
+++ b/Model/NavigationConfig.php
@@ -119,13 +119,9 @@ class NavigationConfig implements ArgumentInterface, FilterFormInputProviderInte
         if ($this->config->isPersonalMerchandisingActive()) {
             $pmCookieName = $this->config->getPersonalMerchandisingCookieName();
             if ($pmCookieName) {
-                $module = $this->request->getModuleName();
-                $controller = $this->request->getControllerName();
                 $result = (!($this->request->getModuleName() == 'tweakwise' && $this->request->getControllerName() == 'ajax'));
                 $navigationFormConfig['tweakwisePMPageReload'] = [
                     'cookieName' => $pmCookieName,
-                    //'reloadList' => false,
-                    'reloadList' => (!($this->request->getModuleName() == 'tweakwise' && $this->request->getControllerName() == 'ajax')),
                 ];
                 $navigationFormConfig['tweakwiseNavigationForm']['ajaxCache'] = false;
             }

--- a/Model/NavigationConfig.php
+++ b/Model/NavigationConfig.php
@@ -119,7 +119,6 @@ class NavigationConfig implements ArgumentInterface, FilterFormInputProviderInte
         if ($this->config->isPersonalMerchandisingActive()) {
             $pmCookieName = $this->config->getPersonalMerchandisingCookieName();
             if ($pmCookieName) {
-                $result = (!($this->request->getModuleName() == 'tweakwise' && $this->request->getControllerName() == 'ajax'));
                 $navigationFormConfig['tweakwisePMPageReload'] = [
                     'cookieName' => $pmCookieName,
                 ];


### PR DESCRIPTION
Currently the first page is reloaded with ajax when using personal merchandising. This is not necessary. This pull request removes the reload, and adds the profile key to the original request so that the page doesn't need to be reloaded but shows the personal merchandising on the first page load.