### PR TITLE
RequireJS dependencies for non-AMD module

### DIFF
--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -10,5 +10,10 @@ var config = {
             productListToolbarForm: 'Emico_Tweakwise/js/toolbar',
             jQueryTouchPunch: 'Emico_Tweakwise/js/lib/jquery.ui.touch-punch.min'
         }
+    },
+    shim: {
+        'jQueryTouchPunch': {
+            'deps': ['jquery-ui-modules/widget', 'jquery-ui-modules/mouse']
+        }
     }
 };


### PR DESCRIPTION
https://github.com/EmicoEcommerce/Magento2Tweakwise/blob/master/view/frontend/web/js/lib/jquery.ui.touch-punch.min.js
The file above has both jQuery/ui-widget and jQuery/ui-mouse documented as dependencies. These should be added as a shim since its a non-AMD script to prevent possible issues (see: https://requirejs.org/docs/api.html#config-shim).

Found this issue after bundling the Javascript files with Magesuite's Magepack in combination with Tweakwise (https://github.com/magesuite/magepack).

Environment:
```
v1.1.6 - emico/m2-attributelanding
v2.3.0 - emico/m2-attributelanding-tweakwise
v3.3.2 - emico/tweakwise
v3.3.0 - emico/tweakwise-export
v1.1.4 - creativestyle/magesuite-magepack

magento/product-community-edition:2.3.6-p1
```