### PR TITLE
Hide settings for autocomplete

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -260,7 +260,7 @@ class Config
      */
     public function isAutocompleteProductsEnabled(Store $store = null)
     {
-        return (bool)$this->getStoreConfig('tweakwise/autocomplete/show_products', $store);
+        return (bool)($this->getStoreConfig('tweakwise/autocomplete/show_products', $store) && !$this->isSuggestionsAutocomplete());
     }
 
     /**
@@ -269,7 +269,7 @@ class Config
      */
     public function isAutocompleteSuggestionsEnabled(Store $store = null)
     {
-        return (bool)$this->getStoreConfig('tweakwise/autocomplete/show_suggestions', $store);
+        return (bool)($this->getStoreConfig('tweakwise/autocomplete/show_suggestions', $store) && !$this->isSuggestionsAutocomplete());
     }
 
     /**

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -145,6 +145,7 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>
                         <field id="enabled">1</field>
+                        <field id="use_suggestions">0</field>
                     </depends>
                 </field>
                 <field id="show_suggestions" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
@@ -152,6 +153,7 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>
                         <field id="enabled">1</field>
+                        <field id="use_suggestions">0</field>
                     </depends>
                 </field>
                 <field id="in_current_category" translate="label,comment" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
@@ -169,6 +171,7 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>
                         <field id="enabled">1</field>
+                        <field id="use_suggestions">0</field>
                     </depends>
                 </field>
             </group>


### PR DESCRIPTION
When enabeling the setting 'use suggestions autocomplete'. Hide the settings for the old autocomplete. 

And disable the old autocomplete call. If the old autocomplete is not disabled, products are shown twice, if those settings have the value YES.