### PR TITLE
Fix grouped/bundeled prices in autocomplete

### DIFF
--- a/Model/Autocomplete/DataProvider/ProductItem.php
+++ b/Model/Autocomplete/DataProvider/ProductItem.php
@@ -75,15 +75,24 @@ class ProductItem implements ItemInterface
     public function toArray(): array
     {
         $product = $this->product;
-        $price = $product->getPriceInfo();
+        $priceInfo = $product->getPriceInfo();
+        $productType = $product->getTypeId();
         $image = $this->getImage();
+
+        $price = (float) $priceInfo->getPrice('regular_price')->getValue();
+
+        if ($productType == 'grouped' || $productType == 'bundle') {
+            $price = (float) $product->getData('tweakwise_price');
+        }
+
+        $finalPrice = (float) $priceInfo->getPrice('final_price')->getValue();
 
         return [
             'title' => $this->getTitle(),
             'url' => $product->getProductUrl(),
             'image' => $image->getImageUrl(),
-            'price' => (float) $price->getPrice('regular_price')->getValue(),
-            'final_price' => (float) $price->getPrice('final_price')->getValue(),
+            'price' => $price,
+            'final_price' => $finalPrice,
             'type' => 'product',
             'row_class' => 'qs-option-product',
         ];

--- a/Model/Autocomplete/DataProvider/ProductItem.php
+++ b/Model/Autocomplete/DataProvider/ProductItem.php
@@ -12,6 +12,8 @@ use Magento\Catalog\Block\Product\Image;
 use Magento\Catalog\Block\Product\ImageBuilder;
 use Magento\Catalog\Block\Product\ImageFactory;
 use Magento\Catalog\Model\Product;
+use Magento\GroupedProduct\Model\Product\Type\Grouped;
+use Magento\Catalog\Model\Product\Type;
 use Magento\Search\Model\Autocomplete\ItemInterface;
 use Magento\Framework\App\ProductMetadataInterface;
 
@@ -81,18 +83,16 @@ class ProductItem implements ItemInterface
 
         $price = (float) $priceInfo->getPrice('regular_price')->getValue();
 
-        if ($productType == 'grouped' || $productType == 'bundle') {
+        if ($productType == Grouped::TYPE_CODE || $productType == Type::TYPE_BUNDLE) {
             $price = (float) $product->getData('tweakwise_price');
         }
-
-        $finalPrice = (float) $priceInfo->getPrice('final_price')->getValue();
 
         return [
             'title' => $this->getTitle(),
             'url' => $product->getProductUrl(),
             'image' => $image->getImageUrl(),
             'price' => $price,
-            'final_price' => $finalPrice,
+            'final_price' => (float) $priceInfo->getPrice('final_price')->getValue(),
             'type' => 'product',
             'row_class' => 'qs-option-product',
         ];

--- a/Model/Autocomplete/DataProviderHelper.php
+++ b/Model/Autocomplete/DataProviderHelper.php
@@ -142,8 +142,9 @@ class DataProviderHelper
         $this->collectionFilter->filter($productCollection, $this->getCategory());
 
         $result = [];
-        foreach ($response->getProductIds() as $productId) {
-            $product = $productCollection->getItemById($productId);
+        foreach ($response->getProductData() as $item) {
+            $product = $productCollection->getItemById($item['id']);
+            $product->setData('tweakwise_price', $item['tweakwise_price']);
             if (!$product) {
                 continue;
             }

--- a/Model/Client/Response/AutocompleteResponse.php
+++ b/Model/Client/Response/AutocompleteResponse.php
@@ -89,4 +89,19 @@ class AutocompleteResponse extends Response implements AutocompleteProductRespon
         }
         return $ids;
     }
+
+    /**
+     * @return array
+     */
+    public function getProductData()
+    {
+        $result = [];
+        foreach ($this->getItems() as $item) {
+            $result[] = [
+                'id' => $this->helper->getStoreId($item->getId()),
+                'tweakwise_price' => (float) $item->getPrice(),
+            ];
+        }
+        return $result;
+    }
 }

--- a/Model/Client/Response/Suggestions/ProductSuggestionsResponse.php
+++ b/Model/Client/Response/Suggestions/ProductSuggestionsResponse.php
@@ -51,4 +51,19 @@ class ProductSuggestionsResponse extends Response implements AutocompleteProduct
         }
         return $ids;
     }
+
+    /**
+     * @return array
+     */
+    public function getProductData()
+    {
+        $result = [];
+        foreach ($this->getItems() as $item) {
+            $result[] = [
+                'id' => $this->helper->getStoreId($item->getId()),
+                'tweakwise_price' => (float) $item->getPrice(),
+            ];
+        }
+        return $result;
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/EmicoEcommerce/Magento2TweakwiseHyva/issues/24

Grouped/bundled prices in the autocomplete dropdown are not correct. This fix uses the price from tweakwise to show in the autocomplete dropdown.